### PR TITLE
strip cruft off published repo.url

### DIFF
--- a/lib/common.js
+++ b/lib/common.js
@@ -55,9 +55,11 @@ function cmdLine(md) {
     /^git-/,
     'git '
   );
-  return md
-    ? `[${cl}](${packageJSON.repository.url}/releases/tag/v${packageJSON.version})`
-    : cl;
+  if (!md) return cl;
+  const baseUrl = packageJSON.repository.url
+    .replace(/^git\+/)
+    .replace(/\.git$/);
+  return `[${cl}](${baseUrl}/releases/tag/v${packageJSON.version})`;
 }
 exports.cmdLine = cmdLine;
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "git-workflow",
+  "name": "git-wf",
   "version": "1.0.1",
   "lockfileVersion": 1,
   "requires": true,

--- a/test/pr.test.js
+++ b/test/pr.test.js
@@ -100,6 +100,11 @@ describe('pr', () => {
         `compare/master...${prefix}:feature/master/kittens-are-cute`,
         url.pathname
       );
+      assert.include(
+        'body has the footer url',
+        'https://github.com/groupon/git-workflow/releases/tag/v',
+        url.query.body
+      );
     });
   });
 });


### PR DESCRIPTION
It was corrupting the link in "This PR was started by" footers

---
_This PR was started by: [git wf pr](https://github.com/groupon/git-workflow/releases/tag/v1.0.1)_