### PR TITLE
feat: respect the presence of a PULL_REQUEST_TEMPALTE.md

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,4 @@
+## Description
+
+Please ensure you adequately describe both the problem you're solving for,
+and the choices you made coming about the solution.

--- a/git-wf.1
+++ b/git-wf.1
@@ -13,7 +13,7 @@ Commands:
   done                      Cleanup current merged, PRed feature branch
   hotfix <buildTag>         Move branch hotfix to given build tag
   merge-back                Merges all changes back from master ← release ← hotfix
-  pr                        Open a PR to merge current feature branch
+  pr [options]              Open a PR to merge current feature branch
   qa [options] [branch]     Tag given (or current) branch as a build
   rename                    Rename local and remote current feature branch
   start [options] <branch>  Create new feature branch from current branch

--- a/lib/commands/pr.js
+++ b/lib/commands/pr.js
@@ -33,6 +33,9 @@
 'use strict';
 
 const open = require('open');
+const process = require('process');
+const fs = require('fs');
+const { join } = require('path');
 
 const {
   ghURL,
@@ -106,17 +109,31 @@ async function prAction({ deps: { git, log }, opts }) {
   }
 
   let title;
-  let body;
+  let body = '';
+
   if (gitLog.total > 1) {
     title =
       findTitle(gitLog.all.map(c => c.subject)) || current.replace(/-/g, ' ');
-    body = [...gitLog.all]
+    body += [...gitLog.all]
       .reverse()
       .map(c => `* ${c.subject}`)
       .join('\n');
   } else {
     title = stripNLMPrefix(gitLog.latest.subject);
-    body = gitLog.latest.body || '';
+    body += gitLog.latest.body || '';
+  }
+
+  body += '\n';
+
+  if (!opts.ignorePrTemplate) {
+    const pathToPrTemplate = join(
+      process.cwd(),
+      '.github',
+      'PULL_REQUEST_TEMPLATE.md'
+    );
+    if (fs.existsSync(pathToPrTemplate)) {
+      body += `${fs.readFileSync(pathToPrTemplate)}\n\n`;
+    }
   }
 
   body += `\n\n\n---\n_This PR was started by: ${cmdLine(true)}_`;
@@ -139,6 +156,10 @@ module.exports = {
     prog
       .command('pr')
       .description('Open a PR to merge current feature branch')
+      .option(
+        '-i, --ignore-pr-template',
+        'Ignores the contents of PULL_REQUEST_TEMPLATE.md'
+      )
       .action(wrapAction(prAction));
   },
 };


### PR DESCRIPTION
## Description

These changes ensure that if a `PULL_REQUEST_TEMPLATE.md` file is present in the repository, it's contents are respected and added to the PR (by default) upon the execution of `git wf pr`.

Additionally, it adds a `-i` option to the command to ignore the template if so desired.

## Also

Hey @dbushong @aotarola @erothman-groupon 👋 
I hope you're all doing well 👍 