### PR TITLE
remove engines requirement

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,10 +20,6 @@
     "test": "mocha",
     "posttest": "nlm verify"
   },
-  "engines": {
-    "npm": "^6.0.0",
-    "yarn": "0.0.0"
-  },
   "man": "git-wf.1",
   "nlm": {
     "license": {


### PR DESCRIPTION
npm 7 is out, and I don't think we need to restrict this to npm 6

---
_This PR was started by: [git wf pr](https://github.com/groupon/git-workflow/releases/tag/v1.3.0)_