### PR TITLE
let squash merge detection be fuzzier

### DIFF
--- a/lib/commands/done.js
+++ b/lib/commands/done.js
@@ -32,6 +32,8 @@
 
 'use strict';
 
+const debug = require('debug')('workflow:done');
+
 const {
   featureParent,
   yesNo,
@@ -40,11 +42,19 @@ const {
   inferRemote,
 } = require('../common');
 
-/**
- * @param {string} diff
- */
+/** @param {string} diff */
 function stripIndexLines(diff) {
   return diff.replace(/^index .*\n/gm, '');
+}
+
+/** @param {string} diff */
+function stripLineNums(diff) {
+  return diff.replace(/^@@ .*\n/gm, '');
+}
+
+/** @param {{ message: string, hash: string }} commit */
+function commitDescr({ message, hash }) {
+  return `[${hash.slice(0, 7)}] ${message}`;
 }
 
 /**
@@ -59,12 +69,32 @@ async function findSquashedDiff(git, feature, parent) {
   const diff = stripIndexLines(await git.diff([`${base}..${feature}`]));
 
   const { all: commits } = await git.log({ from: base, to: parent });
-  for (const { hash, message } of commits) {
-    const show = await git.show([hash]);
+
+  /** @type {Map<typeof commits[0], string>} */
+  const cachedCommitDiffs = new Map();
+
+  for (const commit of commits) {
+    const show = await git.show([commit.hash]);
     // strip off the commit msg at the beginning of the show
     const commitDiff = stripIndexLines(show).replace(/^[\s\S]+?\ndiff/, 'diff');
-    if (commitDiff === diff) return `[${hash.slice(0, 7)}] ${message}`;
+    if (commitDiff === diff) return commitDescr(commit);
+    cachedCommitDiffs.set(commit, commitDiff);
   }
+
+  debug("Couldn't find squashed diff on exact match; fudging line numbers");
+  const strippedDiff = stripLineNums(diff);
+
+  for (const commit of commits) {
+    let commitDiff = cachedCommitDiffs.get(commit);
+    if (!commitDiff) {
+      throw new Error(`Couldn't find cached commit diff for ${commit.hash}`);
+    }
+    commitDiff = stripLineNums(commitDiff);
+    if (commitDiff === strippedDiff) return commitDescr(commit);
+  }
+
+  debug('Failed to find squashed diff match for:');
+  debug(strippedDiff);
 
   return null;
 }


### PR DESCRIPTION
Currently if you don't merge the upstream branch into your feature
branch before merging it back, there's a chance someone else edited the
same files, which will cause your diffs to not necessarily have matching
line numbers.  This patch makes it try a bit harder, but also ignoring
the line number lines in the diff.

---
_This PR was started by: [git wf pr](https://github.com/groupon/git-workflow/releases/tag/v1.3.1)_